### PR TITLE
feat: support tag del and fix readme example typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ const html = `
 </div>
 `;
 
-const DocxGenerator = new DocxGenerator({
+const docxGenerator = new DocxGenerator({
   page: {
     size: {
       width: 5.5,
@@ -66,7 +66,7 @@ const DocxGenerator = new DocxGenerator({
   },
 });
 
-const buffer = await DocxGenerator.generateDocx(html);
+const buffer = await docxGenerator.generateDocx(html);
 
 fs.writeFileSync('example.docx', buffer);
 ```

--- a/src/htmlParser/DocumentElements/DocumentElement.ts
+++ b/src/htmlParser/DocumentElements/DocumentElement.ts
@@ -17,7 +17,7 @@ export type DocumentElementType =
   | EmptyLineType;
 
 export type BlockTextType = 'paragraph' | 'text' | 'heading' | 'list' | 'list-item' | 'blockquote';
-export type InlineTextType = 'br' | 'text' | 'strong' | 'i' | 'u' | 's' | 'a' | 'b' | 'em' | 'span' | 'sup' | 'sub';
+export type InlineTextType = 'br' | 'text' | 'strong' | 'i' | 'u' | 's' | 'del' | 'a' | 'b' | 'em' | 'span' | 'sup' | 'sub';
 export type TableElementType = 'table' | 'table-row' | 'table-cell';
 export type ContainerElementType = 'figure';
 export type ImageType = 'image';

--- a/src/htmlParser/DocumentElements/TextInline.ts
+++ b/src/htmlParser/DocumentElements/TextInline.ts
@@ -14,6 +14,7 @@ export const supportedTextTypes: InlineTextType[] = [
   'i',
   'u',
   's',
+  'del',
   'a',
   'b',
   'em',
@@ -31,6 +32,7 @@ const inlineTextOptionsDictionary: { [key in InlineTextType]: IRunOptions } = {
   i: { italics: true },
   u: { underline: { type: UnderlineType.SINGLE } },
   s: { strike: true },
+  del: { strike: true },
   a: {
     color: LINK_TEXT_COLOR,
     underline: { type: UnderlineType.SINGLE },


### PR DESCRIPTION
typescript warning : Block-scoped variable 'DocxGenerator' used before its declaration.ts(2448)
