### PR TITLE
feat: ol tag support new startIndex

### DIFF
--- a/src/htmlParser/DocumentElements/Document.ts
+++ b/src/htmlParser/DocumentElements/Document.ts
@@ -22,17 +22,18 @@ export class Document {
   constructor(public exportOptions: DocxExportOptions, public children: DocumentElement[]) {}
 
   transformToDocx() {
+    const children = this.children.flatMap(i => i.transformToDocx()) as Paragraph[];
     return new DocxDocument({
       features: { updateFields: true },
       styles: this.getStyles(),
-      numbering: this.getNumberingConfig(),
+      numbering: { config: this.getNumberingConfig() },
       sections: [
         {
           properties: this.getDefaultSectionsProperties(),
           footers: {
             default: this.footer.transformToDocx(),
           },
-          children: this.children.flatMap(i => i.transformToDocx()) as Paragraph[],
+          children,
         },
       ],
     });
@@ -72,14 +73,12 @@ export class Document {
   }
 
   private getNumberingConfig() {
-    return {
-      config: [
-        {
-          reference: DEFAULT_NUMBERING_REF,
-          levels: this.generateNumbering(),
-        },
-      ],
-    };
+    return this.exportOptions.numberingReference.map(reference => {
+      return {
+        reference: reference,
+        levels: this.generateNumbering(),
+      };
+    });
   }
 
   private generateNumbering() {

--- a/src/htmlParser/DocumentElements/List.ts
+++ b/src/htmlParser/DocumentElements/List.ts
@@ -7,6 +7,7 @@ import { ListItem } from './ListItem';
 
 import { TextBlock } from './TextBlock';
 import { TextInline } from './TextInline';
+import { getUUID } from '../utils';
 
 export class List implements DocumentElement {
   type: DocumentElementType = 'list';
@@ -22,8 +23,10 @@ export class List implements DocumentElement {
         break;
       }
       case 'ol': {
+        const reference = `${DEFAULT_NUMBERING_REF}-${getUUID()}`;
+        this.exportOptions.numberingReference.push(reference);
         this.childrenOptions = {
-          numbering: { reference: DEFAULT_NUMBERING_REF, level },
+          numbering: { reference, level },
         };
         this.children = this.getList(element.children);
         break;

--- a/src/htmlParser/utils.ts
+++ b/src/htmlParser/utils.ts
@@ -238,3 +238,11 @@ export const hasSpacesAtStart = (str: string): boolean => {
 export const hasSpacesAtEnd = (str: string): boolean => {
   return str.trimEnd() !== str;
 };
+
+export const getUUID = (): string => {
+  return (
+    Math.random().toString(16).substring(2) +
+    Math.random().toString(16).substring(2) +
+    new Date().getTime().toString(16)
+  ).substr(0, 32);
+};

--- a/src/options/consts.ts
+++ b/src/options/consts.ts
@@ -1,5 +1,6 @@
 import { AlignmentType, NumberFormat } from 'docx';
 import { DocxExportOptions, PageFormatSizes, PageOrientation } from './types';
+import { DEFAULT_NUMBERING_REF } from '../htmlParser/DocumentElements';
 
 export const PageFormat: PageFormatSizes = {
   A3: { width: 11.7, height: 16.5 },
@@ -55,5 +56,6 @@ export const defaultExportOptions: DocxExportOptions = {
   },
   verticalSpaces: 1,
   table: { cellPaddings: defaultTableCellPaddings },
+  numberingReference: [DEFAULT_NUMBERING_REF],
   ignoreIndentation: true,
 };

--- a/src/options/types.ts
+++ b/src/options/types.ts
@@ -64,6 +64,7 @@ export type DocxExportOptions = {
   ignoreIndentation: boolean;
   images?: ImageMap;
   table: TableOptions;
+  numberingReference: string[];
 };
 
 export type TableOptions = {


### PR DESCRIPTION
When I has html
```html
<ol>
    <li>order 1</li>
    <li>order 2</li>
</ol>
<ul>
    <li>list 1</li>
    <li>list 2</li>
</ul>
<table>
    <tr>
        <td>
          <ul>
              <li>Table list 1</li>
              <li>Table list 2</li>
          </ul>
        </td>
        <td>
          <ol>
              <li>Table order 1</li>
              <li>Table order 2</li>
          </ol>
        </td>
    </tr>
</table>
<ol>
    <li>Out order 1</li>
    <li>Out order 2</li>
</ol>
```

I want get docx file like this.
<img width="940" alt="image" src="https://github.com/flexumio/beautiful-docx/assets/820141/9000c184-2540-48dd-b0f0-77bea61ecb21">


Becuse docx module start new index by document option `numbering.config[]`, I add DocxExportOptions numberingReference , support dynamic startIndex.

