### PR TITLE
feat: text support color

### DIFF
--- a/src/htmlParser/DocumentElements/TextInline.ts
+++ b/src/htmlParser/DocumentElements/TextInline.ts
@@ -1,4 +1,4 @@
-import { Element, Node, Styles } from 'himalaya';
+import { Element, Node, Attribute } from 'himalaya';
 import { ExternalHyperlink, IRunOptions, ParagraphChild, ShadingType, TextRun, UnderlineType } from 'docx';
 
 import { cleanTextContent, getAttributeMap, parseStyles } from '../utils';
@@ -48,7 +48,7 @@ export class TextInline implements DocumentElement {
   content: (string | DocumentElement)[];
   isEmpty = false;
 
-  constructor(private element: Node, public options: IRunOptions = {}) {
+  constructor(private element: Node & { attributes?: [Attribute] }, public options: IRunOptions = {}) {
     if (this.element.type === 'text') {
       this.content = [this.element.content];
       this.type = 'text';
@@ -112,6 +112,7 @@ export class TextInline implements DocumentElement {
   }
 
   private get textColor() {
+    if (!this.element.attributes) return undefined;
     const textAttr = getAttributeMap(this.element.attributes);
     const styles = parseStyles(textAttr['style']);
     const color = styles['color'];
@@ -122,6 +123,7 @@ export class TextInline implements DocumentElement {
     return undefined;
   }
   private get textShading() {
+    if (!this.element.attributes) return undefined;
     const textAttr = getAttributeMap(this.element.attributes);
     const styles = parseStyles(textAttr['style']);
     const backgroundColor = styles['background-color'];


### PR DESCRIPTION
 HTML Code
```html
<p><span style="color: #6F81DB;">aa</span></p>
<p><span style="background-color: #E48483;">bb</span></p>
<p>c<span style="background-color: #5593C6;color: #D0DF9D;">c</span>c</p>
```

I want get word style 
<img width="402" alt="image" src="https://github.com/flexumio/beautiful-docx/assets/820141/2b36f76c-b866-4000-b994-609653d096f8">
