### PR TITLE
chore: fix lint errors and enforce lint in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,8 @@ jobs:
 
       - run: npm ci
 
+      - run: npm run lint:ci
+
       - run: npm run build --if-present
 
       - run: npm test

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "prepack": "npm run build",
     "test": "jest",
     "lint": "eslint --quiet --cache --fix",
+    "lint:ci": "eslint src --ext .ts --max-warnings 0",
     "format": "prettier --write",
     "lint-staged": "lint-staged",
     "prepare": "husky install",

--- a/src/DocumentBuilder.test.ts
+++ b/src/DocumentBuilder.test.ts
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import { File } from 'docx';
 import { DocumentBuilder } from './DocumentBuilder';
 import { HtmlParser } from './htmlParser';
@@ -6,13 +7,13 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 jest.mock('axios');
-const axios = require('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 const imageBuffer = fs.readFileSync(path.join(__dirname, '../example/test-icon.png'));
 
 describe('DocumentBuilder', () => {
   beforeEach(() => {
-    axios.get.mockResolvedValue({ data: imageBuffer });
+    mockedAxios.get.mockResolvedValue({ data: imageBuffer });
   });
 
   afterEach(() => {

--- a/src/DocxGenerator.test.ts
+++ b/src/DocxGenerator.test.ts
@@ -1,16 +1,17 @@
+import axios from 'axios';
 import { DocxGenerator } from '.';
 import { defaultExportOptions } from './options';
 import * as fs from 'fs';
 import * as path from 'path';
 
 jest.mock('axios');
-const axios = require('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 const imageBuffer = fs.readFileSync(path.join(__dirname, '../example/test-icon.png'));
 
 describe('DocxGenerator', () => {
   beforeEach(() => {
-    axios.get.mockResolvedValue({ data: imageBuffer });
+    mockedAxios.get.mockResolvedValue({ data: imageBuffer });
   });
 
   afterEach(() => {

--- a/src/htmlParser/DocumentElements/Blockquote.ts
+++ b/src/htmlParser/DocumentElements/Blockquote.ts
@@ -1,5 +1,5 @@
 import { BorderStyle, convertMillimetersToTwip, Paragraph, ParagraphChild } from 'docx';
-import { DocxExportOptions, IParagraphOptions } from '../../options';
+import { IParagraphOptions } from '../../options';
 import { Element, Node } from 'himalaya';
 import { TextInline } from './TextInline';
 import { parseTextAlignment } from '../utils';

--- a/src/htmlParser/DocumentElements/DocumentElement.ts
+++ b/src/htmlParser/DocumentElements/DocumentElement.ts
@@ -17,7 +17,20 @@ export type DocumentElementType =
   | EmptyLineType;
 
 export type BlockTextType = 'paragraph' | 'text' | 'heading' | 'list' | 'list-item' | 'blockquote';
-export type InlineTextType = 'br' | 'text' | 'strong' | 'i' | 'u' | 's' | 'del' | 'a' | 'b' | 'em' | 'span' | 'sup' | 'sub';
+export type InlineTextType =
+  | 'br'
+  | 'text'
+  | 'strong'
+  | 'i'
+  | 'u'
+  | 's'
+  | 'del'
+  | 'a'
+  | 'b'
+  | 'em'
+  | 'span'
+  | 'sup'
+  | 'sub';
 export type TableElementType = 'table' | 'table-row' | 'table-cell';
 export type ContainerElementType = 'figure';
 export type ImageType = 'image';

--- a/src/htmlParser/HtmlParser.test.ts
+++ b/src/htmlParser/HtmlParser.test.ts
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import { defaultExportOptions } from '../options';
 import { Header, Image, ListItem, Paragraph, TableCreator, TextBlock } from './DocumentElements';
 import { HtmlParser } from '.';
@@ -6,14 +7,14 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 jest.mock('axios');
-const axios = require('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 const imageSourceUrl = 'https://example.com/test-image.png';
 const imageBuffer = fs.readFileSync(path.join(__dirname, '../../example/test-icon.png'));
 
 describe('HtmlParser', () => {
   beforeEach(() => {
-    axios.get.mockResolvedValue({ data: imageBuffer });
+    mockedAxios.get.mockResolvedValue({ data: imageBuffer });
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

Cleans up four pre-existing lint errors that had drifted onto \`main\` (CI didn't run lint, so they were never caught), and adds a lint gate to the publish workflow so this can't happen silently again.

- Replaced \`require('axios')\` with \`import axios from 'axios'\` + \`jest.Mocked<typeof axios>\` cast in three test files
- Removed unused \`DocxExportOptions\` import from \`Blockquote.ts\`
- Reformatted \`InlineTextType\` union per prettier
- Added \`lint:ci\` script (\`eslint src --ext .ts --max-warnings 0\` - no \`--fix\`, zero warnings tolerated)
- Added \`npm run lint:ci\` to \`publish.yml\` between \`npm ci\` and \`npm run build\`

The existing \`lint\` script (with \`--fix\` and \`--quiet\`) is unchanged so husky + lint-staged keep working as before.

## Test plan

- [x] \`npm run lint:ci\` passes locally
- [x] \`npm run build\` succeeds
- [x] \`npm test\` passes with 100% branch coverage