### PR TITLE
fix(deps): bump brace-expansion override to ^1.1.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1772,9 +1772,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "js-yaml@3": "^3.15.0",
     "js-yaml@4": "^4.2.0",
     "flatted": "^3.4.2",
-    "brace-expansion": "^1.1.13",
+    "brace-expansion": "^1.1.16",
     "follow-redirects": "^1.16.0",
     "@babel/core": "^7.29.6",
     "form-data": "^4.0.6"


### PR DESCRIPTION
## Summary

- Resolves Dependabot alert #69 (high severity): `brace-expansion < 1.1.16` is vulnerable to a denial of service via exponential-time expansion of consecutive non-expanding `{}` groups.
- `brace-expansion` is a transitive dependency (`eslint` -> `minimatch` -> `brace-expansion`), so the existing `overrides` entry is raised from `^1.1.13` to `^1.1.16`. npm resolves it to `1.1.18`.
- No source changes required.

## Test plan

- [x] `eslint src --ext .ts --max-warnings 0` exits 0
- [x] `npm run build` emits `lib/cjs/` with no TypeScript errors
- [x] `npm test` - 229 tests across 24 suites pass, 100% branch coverage threshold holds
- [x] `npm list brace-expansion` confirms resolved version `1.1.18`